### PR TITLE
Add link to logo to serve as 'go back' from any page

### DIFF
--- a/cypress/fixtures/movies.json
+++ b/cypress/fixtures/movies.json
@@ -1,0 +1,44 @@
+{
+    "movies": [
+      {
+        "id": 694919,
+        "poster_path": "https://image.tmdb.org/t/p/original//6CoRTJTmijhBLJTUNoVSUNxZMEI.jpg",
+        "backdrop_path": "https://image.tmdb.org/t/p/original//pq0JSpwyT2URytdFG0euztQPAyR.jpg",
+        "title": "Money Plane",
+        "average_rating": 6.666666666666667,
+        "release_date": "2020-09-29"
+      },
+      {
+        "id": 337401,
+        "poster_path": "https://image.tmdb.org/t/p/original//aKx1ARwG55zZ0GpRvU2WrGrCG9o.jpg",
+        "backdrop_path": "https://image.tmdb.org/t/p/original//zzWGRw277MNoCs3zhyG3YmYQsXv.jpg",
+        "title": "Mulan",
+        "average_rating": 4.909090909090909,
+        "release_date": "2020-09-04"
+      },
+      {
+        "id": 718444,
+        "poster_path": "https://image.tmdb.org/t/p/original//uOw5JD8IlD546feZ6oxbIjvN66P.jpg",
+        "backdrop_path": "https://image.tmdb.org/t/p/original//x4UkhIQuHIJyeeOTdcbZ3t3gBSa.jpg",
+        "title": "Rogue",
+        "average_rating": 5.428571428571429,
+        "release_date": "2020-08-20"
+      },
+      {
+        "id": 539885,
+        "poster_path": "https://image.tmdb.org/t/p/original//qzA87Wf4jo1h8JMk9GilyIYvwsA.jpg",
+        "backdrop_path": "https://image.tmdb.org/t/p/original//54yOImQgj8i85u9hxxnaIQBRUuo.jpg",
+        "title": "Ava",
+        "average_rating": 5.111111111111111,
+        "release_date": "2020-07-02"
+      },
+      {
+        "id": 581392,
+        "poster_path": "https://image.tmdb.org/t/p/original//sy6DvAu72kjoseZEjocnm2ZZ09i.jpg",
+        "backdrop_path": "https://image.tmdb.org/t/p/original//gEjNlhZhyHeto6Fy5wWy5Uk3A9D.jpg",
+        "title": "Peninsula",
+        "average_rating": 7,
+        "release_date": "2020-07-15"
+      }
+    ]
+  }

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -32,7 +32,6 @@ class App extends Component {
   goBack = () => {
     this.setState({ singleMovie: null });
     this.setState({ error: null })
-    console.log(this.state.error)
   };
 
   checkError = () => {

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -31,6 +31,8 @@ class App extends Component {
 
   goBack = () => {
     this.setState({ singleMovie: null });
+    this.setState({ error: null })
+    console.log(this.state.error)
   };
 
   checkError = () => {
@@ -40,7 +42,7 @@ class App extends Component {
   render() {
     return (
       <main className="App">
-      <Navbar />
+      <Navbar goBack={ this.goBack }/>
         <Switch>
           <Route
             exact path='/' 

--- a/src/Components/Navbar/Navbar.css
+++ b/src/Components/Navbar/Navbar.css
@@ -14,7 +14,12 @@ hr {
 }
 
 .appTitle {
-    color: #F0C808 
+    max-width:100%;
+}
+
+.appTitle > img {
+    max-width:100%;
+    min-width: 146px;
 }
 
 .genreList {

--- a/src/Components/Navbar/Navbar.js
+++ b/src/Components/Navbar/Navbar.js
@@ -1,6 +1,7 @@
 import './Navbar.css';
 import logo from './logo.png';
 import { Component } from 'react';
+import { Link } from 'react-router-dom';
 
 class Navbar extends Component {
   constructor(props) {
@@ -23,7 +24,9 @@ class Navbar extends Component {
   render() {
     return (
       <div className='navbar'>
-          <img src={logo} alt="Rancid Tomatillos logo" className='appTitle' />
+          <Link to="/" className='appTitle' onClick={ this.props.goBack } >
+            <img src={logo} role="button" alt="Rancid Tomatillos logo" />
+          </Link>
           <hr></hr>
           <p>Search by Title:</p>
           <input type="text" value={ this.state.searchBar } onChange={ this.handleChange } />


### PR DESCRIPTION
#### What's this PR do?
* Make logo a link that returns to main view from any page, following Meg's suggestion

#### Where should the reviewer start?
* navbar.js
#### How should this be manually tested?
* type in a url that won't work - e.g., click on a single movie and change the movie id in the url to get an error. Then you can go back to the regular view by clicking the logo.
#### Any background context you want to provide?

#### Are there any issues?
None
#### Next steps:
* README
* Complete Cypress testing
* Refactor to add destructuring (optional)
#### Questions:
